### PR TITLE
Add spec for empty results

### DIFF
--- a/relation_to_struct.gemspec
+++ b/relation_to_struct.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "pg"
+  spec.add_development_dependency "rb-readline"
 
   spec.add_dependency "activerecord", "~> 4.1"
   spec.add_dependency "activesupport", "~> 4.1"

--- a/spec/active_record_base_spec.rb
+++ b/spec/active_record_base_spec.rb
@@ -169,5 +169,11 @@ describe ActiveRecord::Base do
         ActiveRecord::Base.structs_from_sql(test_struct, 'SELECT 1 AS value_a, 2 AS value_c FROM economists')
       end.to raise_error(ArgumentError, 'Expected column names (and their order) to match struct attribute names')
     end
+
+    it 'should return an empty array when sql result is empty' do
+      test_struct = Struct.new(:id)
+      structs_results = ActiveRecord::Base.structs_from_sql(test_struct, 'SELECT id FROM economists WHERE 1 = 0')
+      expect(structs_results).to eq([])
+    end
   end
 end


### PR DESCRIPTION
We have code that depends on `structs_from_sql` returning an empty array if the SQL returns no results.

Added a spec to ensure this is the case going forward.