### PR TITLE
Fix where bind params in ActiveRecord5.0+.

### DIFF
--- a/lib/relation_to_struct/active_record_relation_extension.rb
+++ b/lib/relation_to_struct/active_record_relation_extension.rb
@@ -5,7 +5,15 @@ module RelationToStruct::ActiveRecordRelationExtension
     raise ArgumentError, 'Expected select_values to be present' unless self.select_values.present?
 
     relation = spawn
-    result = klass.connection.select_all(relation.arel, nil, relation.arel.bind_values + bind_values)
+
+    # See the definition of #pluck in:
+    # activerecord/lib/active_record/relation/calculations.rb
+    result = nil
+    if ActiveRecord::VERSION::MAJOR >= 5
+      result = klass.connection.select_all(relation.arel, nil, bound_attributes)
+    else
+      result = klass.connection.select_all(relation.arel, nil, relation.arel.bind_values + bind_values)
+    end
 
     if result.columns.size != struct_class.members.size
       raise ArgumentError, 'Expected struct fields and columns lengths to be equal'

--- a/spec/active_record_relation_spec.rb
+++ b/spec/active_record_relation_spec.rb
@@ -39,6 +39,21 @@ describe ActiveRecord::Relation do
       ).to eq([test_struct.new(hayek.name, austrian.name)])
     end
 
+    it 'incorporates both integer and text where bind parameters' do
+      hayek = Economist.create!(name: 'F.A. Hayek')
+      test_struct = Struct.new(:id, :name)
+
+      structs = Economist
+        .where(
+          :id => [hayek.id],
+          :name => hayek.name,
+        )
+        .select(:id, :name)
+        .to_structs(test_struct)
+
+      expect(structs).to eq([test_struct.new(hayek.id, hayek.name)])
+    end
+
     it 'properly casts values from arbitrary calculated columns' do
       hayek = Economist.create!(name: 'F.A. Hayek')
       scope = Economist.all


### PR DESCRIPTION
In the upgrade to 5.0/5.1 I didn't catch that ActiveRecord's bind
parameters interface had changed. Unfortunately it kept working for
certain arguments (apparently integers get folded in directly), but
text parameters weren't getting incorporated into the resulting SQL
which resulted in queries failing to execute.