### PR TITLE
Explicitly disable query caching for ActiveRecord::Base extensions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ eos
 ActiveRecord::Base.tuple_from_sql(sql) # => [id, name]
 ```
 
+## Project Policy/Philosophy
+
+Executing database queries should be clearly explicit in your application code. Implicit queries (e.g., in association accesses) is an anti-pattern that results in problems like N+1 querying.
+
+### Query Caching
+
+Query caching is another problem downstream from implicit querying. Because queries are happening "behind the scenes" and there's no obvious place for explicit result caching, it seems desirable to cache at the query level. But this approach applies caching at the wrong level: your application code must still expend all of the effort required to build a SQL query and (potentially) interpret results. Caching queries automatically (as Rails does by default in a web request) can easily lead to gotchas because the framework has no way of determining when caching is actually safe (both from a business logic and query contents perspective).
+
+For this reason, **all methods added to `ActiveRecord::Base` explicitly disable query caching**. Rails defaults are respected, however, on extensions to `ActiveRecord::Relation` since it's not as obvious that those queries are intended to be explicit.
+
 ## Contributing
 
 1. Fork it ( https://github.com/jcoleman/relation_to_struct/fork )

--- a/lib/relation_to_struct/active_record_base_extension.rb
+++ b/lib/relation_to_struct/active_record_base_extension.rb
@@ -8,7 +8,9 @@ module RelationToStruct::ActiveRecordBaseExtension
 
     def structs_from_sql(struct_class, sql, binds=[])
       sanitized_sql = _sanitize_sql_for_relation_to_struct(sql)
-      result = connection.select_all(sanitized_sql, "Structs SQL Load", binds)
+      result = ActiveRecord::Base.uncached do
+        connection.select_all(sanitized_sql, "Structs SQL Load", binds)
+      end
 
       if result.columns.size != result.columns.uniq.size
         raise ArgumentError, 'Expected column names to be unique'
@@ -31,13 +33,17 @@ module RelationToStruct::ActiveRecordBaseExtension
 
     def pluck_from_sql(sql, binds=[])
       sanitized_sql = _sanitize_sql_for_relation_to_struct(sql)
-      result = connection.select_all(sanitized_sql, "Pluck SQL Load", binds)
+      result = ActiveRecord::Base.uncached do
+        connection.select_all(sanitized_sql, "Pluck SQL Load", binds)
+      end
       result.cast_values()
     end
 
     def value_from_sql(sql, binds=[])
       sanitized_sql = _sanitize_sql_for_relation_to_struct(sql)
-      result = connection.select_all(sanitized_sql, "Value SQL Load", binds)
+      result = ActiveRecord::Base.uncached do
+        connection.select_all(sanitized_sql, "Value SQL Load", binds)
+      end
       raise ArgumentError, 'Expected exactly one column to be selected' unless result.columns.size == 1
 
       values = result.cast_values()
@@ -53,7 +59,9 @@ module RelationToStruct::ActiveRecordBaseExtension
 
     def tuple_from_sql(sql, binds=[])
       sanitized_sql = _sanitize_sql_for_relation_to_struct(sql)
-      result = connection.select_all(sanitized_sql, "Value SQL Load", binds)
+      result = ActiveRecord::Base.uncached do
+        connection.select_all(sanitized_sql, "Value SQL Load", binds)
+      end
       values = result.cast_values()
 
       case values.size

--- a/spec/active_record_base_spec.rb
+++ b/spec/active_record_base_spec.rb
@@ -16,6 +16,20 @@ describe ActiveRecord::Base do
       sql = "SELECT 1 * 23, 25"
       expect(ActiveRecord::Base.pluck_from_sql(sql)).to eq([[23, 25]])
     end
+
+    it 'bypasses the statement cache' do
+      sql = "SELECT random()"
+      value_1 = value_2 = nil
+
+      # Simulate a standard web request in Rails, since
+      # Rails enabled caching by default.
+      ActiveRecord::Base.cache do
+        value_1 = ActiveRecord::Base.pluck_from_sql(sql)
+        value_2 = ActiveRecord::Base.pluck_from_sql(sql)
+      end
+
+      expect(value_1).not_to eq(value_2)
+    end
   end
 
   describe "#value_from_sql" do
@@ -53,6 +67,20 @@ describe ActiveRecord::Base do
       else
         skip "DB selection doesn't support ARRAY[]"
       end
+    end
+
+    it 'bypasses the statement cache' do
+      sql = "SELECT random()"
+      value_1 = value_2 = nil
+
+      # Simulate a standard web request in Rails, since
+      # Rails enabled caching by default.
+      ActiveRecord::Base.cache do
+        value_1 = ActiveRecord::Base.value_from_sql(sql)
+        value_2 = ActiveRecord::Base.value_from_sql(sql)
+      end
+
+      expect(value_1).not_to eq(value_2)
     end
   end
 
@@ -112,6 +140,20 @@ describe ActiveRecord::Base do
         skip "DB selection doesn't support ARRAY[]"
       end
     end
+
+    it 'bypasses the statement cache' do
+      sql = "SELECT random()"
+      value_1 = value_2 = nil
+
+      # Simulate a standard web request in Rails, since
+      # Rails enabled caching by default.
+      ActiveRecord::Base.cache do
+        value_1 = ActiveRecord::Base.tuple_from_sql(sql)
+        value_2 = ActiveRecord::Base.tuple_from_sql(sql)
+      end
+
+      expect(value_1).not_to eq(value_2)
+    end
   end
 
   describe "#structs_from_sql" do
@@ -168,6 +210,21 @@ describe ActiveRecord::Base do
         test_struct = Struct.new(:value_a, :value_b)
         ActiveRecord::Base.structs_from_sql(test_struct, 'SELECT 1 AS value_a, 2 AS value_c FROM economists')
       end.to raise_error(ArgumentError, 'Expected column names (and their order) to match struct attribute names')
+    end
+
+    it 'bypasses the statement cache' do
+      test_struct = Struct.new(:r)
+      sql = "SELECT random() AS r"
+      value_1 = value_2 = nil
+
+      # Simulate a standard web request in Rails, since
+      # Rails enabled caching by default.
+      ActiveRecord::Base.cache do
+        value_1 = ActiveRecord::Base.structs_from_sql(test_struct, sql)
+        value_2 = ActiveRecord::Base.structs_from_sql(test_struct, sql)
+      end
+
+      expect(value_1).not_to eq(value_2)
     end
   end
 end


### PR DESCRIPTION
The API is designed to be used to execute queries explicitly, and
there's no way for the framework to know if it's safe to cache queries
(either for business logic or SQL semantics reasons). Since it's
surprising to have explicit SQL queries magically cached, we disable
query caching.