### PR TITLE
Add ActiveRecord::Base#run_sql.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ eos
 ActiveRecord::Base.tuple_from_sql(sql) # => [id, name]
 ```
 
+```
+sql = <<-eos
+  SELECT 1
+eos
+
+ActiveRecord::Base.run_sql(sql) # => <no defined result>
+```
+
+```
+sql = <<-eos
+  INSERT INTO foos(bar) VALUES(1)
+eos
+
+ActiveRecord::Base.run_sql(sql) # => <number of rows modified>
+```
+
 ## Project Policy/Philosophy
 
 Executing database queries should be clearly explicit in your application code. Implicit queries (e.g., in association accesses) is an anti-pattern that results in problems like N+1 querying.

--- a/lib/relation_to_struct/active_record_base_extension.rb
+++ b/lib/relation_to_struct/active_record_base_extension.rb
@@ -73,6 +73,15 @@ module RelationToStruct::ActiveRecordBaseExtension
         raise ArgumentError, 'Expected only a single result to be returned'
       end
     end
+
+    def run_sql(sql, binds=[])
+      sanitized_sql = _sanitize_sql_for_relation_to_struct(sql)
+      # We don't need to build a result set unnecessarily; using
+      # interface this also ensures we're clearing the result set
+      # for manually memory managed object (e.g., when using the
+      # PostgreSQL adaptor).
+      connection.exec_update(sanitized_sql, "Run SQL", binds)
+    end
   end
 end
 


### PR DESCRIPTION
This new API method allow execution of arbitrary SQL without implying
that you care about the result set. While at some level that makes it
feel like it's just a substitute for `#value_from_sql` and friends with
different code reading implications, it also as a different functional
value: for modification queries it returns the number of tuples
modified.

In addition it guarantees that the result set isn't turned into an
`ActiveRecord::Result` (to avoid overhead) and that any manual memory
allocation is handled (to avoid problems with `Connection#execute` on
PostgreSQL, for example.

Like all of the other extensions to `ActiveRecord::Base` this method
guarantees that no query caching occurs.