### PR TITLE
Extend interface to ActiveRecord::Base.connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ relation.to_structs(UserPostsSummary) # => array of structs
 
 ### From raw SQL
 
+Note: In order to provide a consistent user experience regardless of the abstraction level used by your code, all of the following methods are available on both `ActiveRecord::Base` and `ActiveRecord::Base.connection`.
+
 ```
 UserPostsSummary = Struct.new(:user_name, :post_count)
 sql = <<-eos

--- a/lib/relation_to_struct.rb
+++ b/lib/relation_to_struct.rb
@@ -1,4 +1,5 @@
 require "relation_to_struct/version"
+require "relation_to_struct/active_record_connection_adapter_extension"
 require "relation_to_struct/active_record_base_extension"
 require "relation_to_struct/active_record_relation_extension"
 

--- a/lib/relation_to_struct/active_record_base_extension.rb
+++ b/lib/relation_to_struct/active_record_base_extension.rb
@@ -1,88 +1,18 @@
 module RelationToStruct::ActiveRecordBaseExtension
-  extend ::ActiveSupport::Concern
-
   module ClassMethods
     def _sanitize_sql_for_relation_to_struct(sql)
       sanitized_sql = ActiveRecord::VERSION::MAJOR >= 5 ? sanitize_sql(sql) : sanitize_sql(sql, nil)
     end
 
-    def structs_from_sql(struct_class, sql, binds=[])
-      sanitized_sql = _sanitize_sql_for_relation_to_struct(sql)
-      result = ActiveRecord::Base.uncached do
-        connection.select_all(sanitized_sql, "Structs SQL Load", binds)
-      end
-
-      if result.columns.size != result.columns.uniq.size
-        raise ArgumentError, 'Expected column names to be unique'
-      end
-
-      if result.columns != struct_class.members.collect(&:to_s)
-        raise ArgumentError, 'Expected column names (and their order) to match struct attribute names'
-      end
-
-      if result.columns.size == 1
-        result.cast_values().map do |tuple|
-          struct_class.new(tuple)
-        end
-      else
-        result.cast_values().map do |tuple|
-          struct_class.new(*tuple)
-        end
-      end
-    end
-
-    def pluck_from_sql(sql, binds=[])
-      sanitized_sql = _sanitize_sql_for_relation_to_struct(sql)
-      result = ActiveRecord::Base.uncached do
-        connection.select_all(sanitized_sql, "Pluck SQL Load", binds)
-      end
-      result.cast_values()
-    end
-
-    def value_from_sql(sql, binds=[])
-      sanitized_sql = _sanitize_sql_for_relation_to_struct(sql)
-      result = ActiveRecord::Base.uncached do
-        connection.select_all(sanitized_sql, "Value SQL Load", binds)
-      end
-      raise ArgumentError, 'Expected exactly one column to be selected' unless result.columns.size == 1
-
-      values = result.cast_values()
-      case values.size
-      when 0
-        nil
-      when 1
-        values[0]
-      else
-        raise ArgumentError, 'Expected only a single result to be returned'
-      end
-    end
-
-    def tuple_from_sql(sql, binds=[])
-      sanitized_sql = _sanitize_sql_for_relation_to_struct(sql)
-      result = ActiveRecord::Base.uncached do
-        connection.select_all(sanitized_sql, "Value SQL Load", binds)
-      end
-      values = result.cast_values()
-
-      case values.size
-      when 0
-        nil
-      when 1
-        result.columns.size == 1 ? values : values[0]
-      else
-        raise ArgumentError, 'Expected only a single result to be returned'
-      end
-    end
-
-    def run_sql(sql, binds=[])
-      sanitized_sql = _sanitize_sql_for_relation_to_struct(sql)
-      # We don't need to build a result set unnecessarily; using
-      # interface this also ensures we're clearing the result set
-      # for manually memory managed object (e.g., when using the
-      # PostgreSQL adaptor).
-      connection.exec_update(sanitized_sql, "Run SQL", binds)
-    end
+    delegate(
+      :structs_from_sql,
+      :pluck_from_sql,
+      :value_from_sql,
+      :tuple_from_sql,
+      :run_sql,
+      :to => :connection
+    )
   end
 end
 
-::ActiveRecord::Base.send(:include, RelationToStruct::ActiveRecordBaseExtension)
+::ActiveRecord::Base.singleton_class.send(:prepend, RelationToStruct::ActiveRecordBaseExtension::ClassMethods)

--- a/lib/relation_to_struct/active_record_connection_adapter_extension.rb
+++ b/lib/relation_to_struct/active_record_connection_adapter_extension.rb
@@ -1,0 +1,80 @@
+module RelationToStruct::ActiveRecordConnectionAdapterExtension
+  def structs_from_sql(struct_class, sql, binds=[])
+    sanitized_sql = ActiveRecord::Base._sanitize_sql_for_relation_to_struct(sql)
+    result = ActiveRecord::Base.uncached do
+      select_all(sanitized_sql, "Structs SQL Load", binds)
+    end
+
+    if result.columns.size != result.columns.uniq.size
+      raise ArgumentError, 'Expected column names to be unique'
+    end
+
+    if result.columns != struct_class.members.collect(&:to_s)
+      raise ArgumentError, 'Expected column names (and their order) to match struct attribute names'
+    end
+
+    if result.columns.size == 1
+      result.cast_values().map do |tuple|
+        struct_class.new(tuple)
+      end
+    else
+      result.cast_values().map do |tuple|
+        struct_class.new(*tuple)
+      end
+    end
+  end
+
+  def pluck_from_sql(sql, binds=[])
+    sanitized_sql = ActiveRecord::Base._sanitize_sql_for_relation_to_struct(sql)
+    result = ActiveRecord::Base.uncached do
+      select_all(sanitized_sql, "Pluck SQL Load", binds)
+    end
+    result.cast_values()
+  end
+
+  def value_from_sql(sql, binds=[])
+    sanitized_sql = ActiveRecord::Base._sanitize_sql_for_relation_to_struct(sql)
+    result = ActiveRecord::Base.uncached do
+      select_all(sanitized_sql, "Value SQL Load", binds)
+    end
+    raise ArgumentError, 'Expected exactly one column to be selected' unless result.columns.size == 1
+
+    values = result.cast_values()
+    case values.size
+    when 0
+      nil
+    when 1
+      values[0]
+    else
+      raise ArgumentError, 'Expected only a single result to be returned'
+    end
+  end
+
+  def tuple_from_sql(sql, binds=[])
+    sanitized_sql = ActiveRecord::Base._sanitize_sql_for_relation_to_struct(sql)
+    result = ActiveRecord::Base.uncached do
+      select_all(sanitized_sql, "Value SQL Load", binds)
+    end
+    values = result.cast_values()
+
+    case values.size
+    when 0
+      nil
+    when 1
+      result.columns.size == 1 ? values : values[0]
+    else
+      raise ArgumentError, 'Expected only a single result to be returned'
+    end
+  end
+
+  def run_sql(sql, binds=[])
+    sanitized_sql = ActiveRecord::Base._sanitize_sql_for_relation_to_struct(sql)
+    # We don't need to build a result set unnecessarily; using
+    # interface this also ensures we're clearing the result set
+    # for manually memory managed object (e.g., when using the
+    # PostgreSQL adaptor).
+    exec_update(sanitized_sql, "Run SQL", binds)
+  end
+end
+
+::ActiveRecord::ConnectionAdapters::AbstractAdapter.send(:prepend, RelationToStruct::ActiveRecordConnectionAdapterExtension)

--- a/lib/relation_to_struct/active_record_relation_extension.rb
+++ b/lib/relation_to_struct/active_record_relation_extension.rb
@@ -1,6 +1,4 @@
 module RelationToStruct::ActiveRecordRelationExtension
-  extend ::ActiveSupport::Concern
-
   def to_structs(struct_class)
     raise ArgumentError, 'Expected select_values to be present' unless self.select_values.present?
 
@@ -37,4 +35,4 @@ module RelationToStruct::ActiveRecordRelationExtension
   end
 end
 
-::ActiveRecord::Relation.send(:include, RelationToStruct::ActiveRecordRelationExtension)
+::ActiveRecord::Relation.send(:prepend, RelationToStruct::ActiveRecordRelationExtension)

--- a/spec/active_record_connection_adapter_spec.rb
+++ b/spec/active_record_connection_adapter_spec.rb
@@ -1,0 +1,270 @@
+require 'spec_helper'
+
+describe ActiveRecord::ConnectionAdapters::AbstractAdapter do
+  before(:each) do
+    Economist.delete_all
+    EconomicSchool.delete_all
+  end
+
+  let(:connection) { ActiveRecord::Base.connection }
+
+  describe "#pluck_from_sql" do
+    it 'allows plucking with SQL directly' do
+      sql = "SELECT 1 * 23"
+      expect(connection.pluck_from_sql(sql)).to eq([23])
+    end
+
+    it 'allows plucking multiple columns with SQL directly' do
+      sql = "SELECT 1 * 23, 25"
+      expect(connection.pluck_from_sql(sql)).to eq([[23, 25]])
+    end
+
+    it 'bypasses the statement cache' do
+      sql = "SELECT random()"
+      value_1 = value_2 = nil
+
+      # Simulate a standard web request in Rails, since
+      # Rails enabled caching by default.
+      ActiveRecord::Base.cache do
+        value_1 = connection.pluck_from_sql(sql)
+        value_2 = connection.pluck_from_sql(sql)
+      end
+
+      expect(value_1).not_to eq(value_2)
+    end
+  end
+
+  describe "#value_from_sql" do
+    it 'allows selecting a value with SQL directly' do
+      sql = "SELECT 1 * 23"
+      expect(connection.value_from_sql(sql)).to eq(23)
+    end
+
+    it 'raises an error when multiple rows are selected' do
+      expect do
+        sql = "SELECT * FROM (VALUES (1), (2)) t"
+        connection.value_from_sql(sql)
+      end.to raise_error(ArgumentError, 'Expected only a single result to be returned')
+    end
+
+    it 'raises an error when multiple columns are selected' do
+      expect do
+        sql = "SELECT 1, 2"
+        connection.value_from_sql(sql)
+      end.to raise_error(ArgumentError, 'Expected exactly one column to be selected')
+    end
+
+    it 'supports binds' do
+      sql = ["SELECT 1 * ?", 5]
+      expect(connection.value_from_sql(sql)).to eq(5)
+    end
+
+    it 'supports arrays' do
+      if active_record_supports_arrays?
+        Economist.create!(name: 'F.A. Hayek')
+        Economist.create!(name: 'Ludwig von Mises')
+
+        result = connection.value_from_sql('SELECT ARRAY_AGG(name ORDER BY id) AS names FROM economists')
+        expect(result).to eq(['F.A. Hayek', 'Ludwig von Mises'])
+      else
+        skip "DB selection doesn't support ARRAY[]"
+      end
+    end
+
+    it 'bypasses the statement cache' do
+      sql = "SELECT random()"
+      value_1 = value_2 = nil
+
+      # Simulate a standard web request in Rails, since
+      # Rails enabled caching by default.
+      ActiveRecord::Base.cache do
+        value_1 = connection.value_from_sql(sql)
+        value_2 = connection.value_from_sql(sql)
+      end
+
+      expect(value_1).not_to eq(value_2)
+    end
+  end
+
+  describe "#tuple_from_sql" do
+    it 'allows selecting one value with SQL directly' do
+      sql = "SELECT 1"
+      expect(connection.tuple_from_sql(sql)).to eq([1])
+    end
+
+    it 'allows selecting multiple values with SQL directly' do
+      sql = "SELECT 1, 23"
+      expect(connection.tuple_from_sql(sql)).to eq([1, 23])
+    end
+
+    it 'raises an error when multiple rows are selected' do
+      expect do
+        sql = "SELECT * FROM (VALUES (1, 3), (2, 4)) t"
+        connection.tuple_from_sql(sql)
+      end.to raise_error(ArgumentError, 'Expected only a single result to be returned')
+    end
+
+    it 'supports binds' do
+      sql = ["SELECT ?, ?", 5, 6]
+      expect(connection.tuple_from_sql(sql)).to eq([5, 6])
+    end
+
+    it 'supports a single array' do
+      if active_record_supports_arrays?
+        Economist.create!(name: 'F.A. Hayek')
+        Economist.create!(name: 'Ludwig von Mises')
+
+        result = connection.tuple_from_sql(<<-SQL)
+          SELECT ARRAY_AGG(name ORDER BY id) AS names
+          FROM economists
+        SQL
+        expected_names = ['F.A. Hayek', 'Ludwig von Mises']
+        expect(result).to eq([expected_names])
+      else
+        skip "DB selection doesn't support ARRAY[]"
+      end
+    end
+
+    it 'supports multiple arrays' do
+      if active_record_supports_arrays?
+        Economist.create!(name: 'F.A. Hayek')
+        Economist.create!(name: 'Ludwig von Mises')
+
+        result = connection.tuple_from_sql(<<-SQL)
+          SELECT
+            ARRAY_AGG(name ORDER BY id) AS names,
+            ARRAY_AGG(CHAR_LENGTH(name) ORDER BY id) AS lengths
+          FROM economists
+        SQL
+        expected_names = ['F.A. Hayek', 'Ludwig von Mises']
+        expect(result).to eq([expected_names, expected_names.map(&:size)])
+      else
+        skip "DB selection doesn't support ARRAY[]"
+      end
+    end
+
+    it 'bypasses the statement cache' do
+      sql = "SELECT random()"
+      value_1 = value_2 = nil
+
+      # Simulate a standard web request in Rails, since
+      # Rails enabled caching by default.
+      ActiveRecord::Base.cache do
+        value_1 = connection.tuple_from_sql(sql)
+        value_2 = connection.tuple_from_sql(sql)
+      end
+
+      expect(value_1).not_to eq(value_2)
+    end
+  end
+
+  describe "#structs_from_sql" do
+    it 'ActiveRecord::Base should respond to :structs_from_sql' do
+      expect(connection.respond_to?(:structs_from_sql)).to eq(true)
+    end
+
+    it 'allows querying with SQL directly' do
+      test_struct = Struct.new(:number)
+      sql = "SELECT 1 * 23 AS number"
+      expect(connection.structs_from_sql(test_struct, sql)).to eq([test_struct.new(23)])
+    end
+
+    it 'properly casts a single array column' do
+      if active_record_supports_arrays?
+        Economist.create!(name: 'F.A. Hayek')
+        Economist.create!(name: 'Ludwig von Mises')
+
+        test_struct = Struct.new(:names)
+        structs_results = connection.structs_from_sql(test_struct, 'SELECT ARRAY_AGG(name ORDER BY id) AS names FROM economists')
+        expect(structs_results.first.names).to eq(['F.A. Hayek', 'Ludwig von Mises'])
+      else
+        skip "DB selection doesn't support ARRAY[]"
+      end
+    end
+
+    it 'raises an error when column count does not match struct size' do
+      expect do
+        test_struct = Struct.new(:id, :name, :extra_field)
+        connection.structs_from_sql(test_struct, 'SELECT id, name FROM economists')
+      end.to raise_error(ArgumentError, 'Expected column names (and their order) to match struct attribute names')
+    end
+
+    it 'raises an error when column names are not unique' do
+      expect do
+        test_struct = Struct.new(:id, :id2)
+        connection.structs_from_sql(test_struct, 'SELECT id, id FROM economists')
+      end.to raise_error(ArgumentError, 'Expected column names to be unique')
+    end
+
+    it 'raises an error when the column names do not match the struct attribute names' do
+      Economist.create!(name: 'F.A. Hayek')
+      expect do
+        test_struct = Struct.new(:value_a, :value_b)
+        connection.structs_from_sql(test_struct, 'SELECT 1 AS value_a, 2 AS value_b FROM economists')
+      end.not_to raise_error
+
+      expect do
+        test_struct = Struct.new(:value_a, :value_b)
+        connection.structs_from_sql(test_struct, 'SELECT 1 AS value_b, 2 AS value_a FROM economists')
+      end.to raise_error(ArgumentError, 'Expected column names (and their order) to match struct attribute names')
+
+      expect do
+        test_struct = Struct.new(:value_a, :value_b)
+        connection.structs_from_sql(test_struct, 'SELECT 1 AS value_a, 2 AS value_c FROM economists')
+      end.to raise_error(ArgumentError, 'Expected column names (and their order) to match struct attribute names')
+    end
+
+    it 'bypasses the statement cache' do
+      test_struct = Struct.new(:r)
+      sql = "SELECT random() AS r"
+      value_1 = value_2 = nil
+
+      # Simulate a standard web request in Rails, since
+      # Rails enabled caching by default.
+      ActiveRecord::Base.cache do
+        value_1 = connection.structs_from_sql(test_struct, sql)
+        value_2 = connection.structs_from_sql(test_struct, sql)
+      end
+
+      expect(value_1).not_to eq(value_2)
+    end
+  end
+
+  describe "#run_sql" do
+    it 'executes the provided SQL' do
+      sql = "INSERT INTO economic_schools(name) VALUES ('Chicago')"
+      expect do
+        ActiveRecord::Base.run_sql(sql)
+      end.to change { connection.value_from_sql("SELECT COUNT(*) FROM economic_schools") }.by(1)
+    end
+
+    it 'supports binds' do
+      sql = ["INSERT INTO economic_schools(name) VALUES (?)", "Chicago"]
+      expect do
+        ActiveRecord::Base.run_sql(sql)
+      end.to change { connection.value_from_sql("SELECT COUNT(*) FROM economic_schools") }.by(1)
+    end
+
+    it 'uses the exec_update API to avoid turning things in an ActiveRecord::Result' do
+      expect(ActiveRecord::Base.connection).to receive(:exec_update).exactly(:once)
+      sql = "SELECT 1"
+      connection.run_sql(sql)
+    end
+
+    it 'returns the number of rows modified for an INSERT' do
+      sql = "INSERT INTO economic_schools(name) VALUES ('Chicago'), ('Distributism')"
+      expect(connection.run_sql(sql)).to eq(2)
+    end
+
+    it 'bypasses the statement cache' do
+      # Simulate a standard web request in Rails, since
+      # Rails enabled caching by default.
+      ActiveRecord::Base.cache do
+        expect do
+          connection.run_sql("INSERT INTO economic_schools(name) VALUES ('Chicago')")
+          connection.run_sql("INSERT INTO economic_schools(name) VALUES ('Distributism')")
+        end.to change { connection.value_from_sql("SELECT COUNT(*) FROM economic_schools") }.by(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sometimes an app may intentionally build ActiveRecord connections
directly. In that case you don't necessarily have access to the
connection via `ActiveRecord::Base`, which makes the functionality
provided by this gem on `ActiveRecord::Base` hard (or impossible) to
use. Since all of the functionality ends up invoking calls on the
connection adapter anyway, we can move the implementations to the
connection adapter itself and delegate from `ActiveRecord::Base`, thus
supporting the same interface from both call paths.

Along the way I switched to using direct prepends instead of
`ActiveSupport::Concern`.