### PR TITLE
Add support for Rails 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,20 +5,19 @@ jobs:
     strategy:
       matrix:
         pg:
-          - 11
-          - 12
           - 13
           - 14
           - 15
           - 16
+          - 17
         ruby:
-          - "3.1"
           - "3.2"
+          - "3.3"
         gemfile:
-          - rails_6_1
           - rails_7_0
           - rails_7_1
           - rails_7_2
+          - rails_8_0
     name: PostgreSQL ${{ matrix.pg }} - Ruby ${{ matrix.ruby }} - ${{ matrix.gemfile }}
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
@@ -41,13 +40,13 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "3.1"
           - "3.2"
+          - "3.3"
         gemfile:
-          - rails_6_1
           - rails_7_0
           - rails_7_1
           - rails_7_2
+          - rails_8_0
     name: SQLite - Ruby ${{ matrix.ruby }} - ${{ matrix.gemfile }}
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps

--- a/Appraisals
+++ b/Appraisals
@@ -1,5 +1,6 @@
-%w(6.1 7.0 7.1 7.2).each do |version|
+%w(7.0 7.1 7.2 8.0).each do |version|
   appraise "rails-#{version.gsub(/\./, "-")}" do
     gem "rails", "~> #{version}.0"
+    gem "sqlite3", "~> 1.4" if version == "7.0"
   end
 end

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.0.0"
+gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 6.1.0"
+gem "rails", "~> 8.0.0"
 
 gemspec path: "../"

--- a/relation_to_struct.gemspec
+++ b/relation_to_struct.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "appraisal", ">= 2.5"
   spec.add_development_dependency "bundler", ">= 1.7"
   spec.add_development_dependency "rake", ">= 10.0"
-  spec.add_development_dependency "sqlite3", "~> 1.4"
+  spec.add_development_dependency "sqlite3", ">= 1.4"
   spec.add_development_dependency "rspec", ">= 3.2"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "pg"
 
-  spec.add_dependency "activerecord", ">= 6.1", "< 7.3"
-  spec.add_dependency "activesupport", ">= 6.1", "< 7.3"
+  spec.add_dependency "activerecord", ">= 7.0", "< 8.1"
+  spec.add_dependency "activesupport", ">= 7.0", "< 8.1"
 end


### PR DESCRIPTION
Also:

- Drop support for EOL Rails 6.1
- Remove builds for EOL Postgres 11 / 12
- Remove builds for Ruby 3.1 (Rails 8 only supports 3.2+)
- Add Postgres 17 builds
- Add Ruby 3.3 builds