### PR TITLE
Fix uncached to operate on the connection's own pool rather than ActiveRecord::Base's pool

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,6 +1,5 @@
 %w(7.2 8.0 8.1).each do |version|
   appraise "rails-#{version.gsub(/\./, "-")}" do
     gem "rails", "~> #{version}.0"
-    gem "sqlite3", "~> 1.4"
   end
 end

--- a/lib/relation_to_struct/active_record_connection_adapter_extension.rb
+++ b/lib/relation_to_struct/active_record_connection_adapter_extension.rb
@@ -1,7 +1,7 @@
 module RelationToStruct::ActiveRecordConnectionAdapterExtension
   def structs_from_sql(struct_class, sql, binds=[])
     sanitized_sql = ActiveRecord::Base.sanitize_sql(sql)
-    result = ActiveRecord::Base.uncached do
+    result = uncached do
       select_all(sanitized_sql, "Structs SQL Load", binds)
     end
 
@@ -26,7 +26,7 @@ module RelationToStruct::ActiveRecordConnectionAdapterExtension
 
   def pluck_from_sql(sql, binds=[])
     sanitized_sql = ActiveRecord::Base.sanitize_sql(sql)
-    result = ActiveRecord::Base.uncached do
+    result = uncached do
       select_all(sanitized_sql, "Pluck SQL Load", binds)
     end
     result.cast_values()
@@ -34,7 +34,7 @@ module RelationToStruct::ActiveRecordConnectionAdapterExtension
 
   def value_from_sql(sql, binds=[])
     sanitized_sql = ActiveRecord::Base.sanitize_sql(sql)
-    result = ActiveRecord::Base.uncached do
+    result = uncached do
       select_all(sanitized_sql, "Value SQL Load", binds)
     end
     raise ArgumentError, 'Expected exactly one column to be selected' unless result.columns.size == 1
@@ -52,7 +52,7 @@ module RelationToStruct::ActiveRecordConnectionAdapterExtension
 
   def tuple_from_sql(sql, binds=[])
     sanitized_sql = ActiveRecord::Base.sanitize_sql(sql)
-    result = ActiveRecord::Base.uncached do
+    result = uncached do
       select_all(sanitized_sql, "Value SQL Load", binds)
     end
     values = result.cast_values()

--- a/lib/relation_to_struct/version.rb
+++ b/lib/relation_to_struct/version.rb
@@ -1,3 +1,3 @@
 module RelationToStruct
-  VERSION = "1.11.0"
+  VERSION = "1.11.1"
 end

--- a/relation_to_struct.gemspec
+++ b/relation_to_struct.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "appraisal", ">= 2.5"
   spec.add_development_dependency "bundler", ">= 1.7"
   spec.add_development_dependency "rake", ">= 10.0"
-  spec.add_development_dependency "sqlite3", ">= 1.4"
+  spec.add_development_dependency "sqlite3", ">= 2.1"
   spec.add_development_dependency "rspec", ">= 3.2"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "pg"

--- a/spec/active_record_base_spec.rb
+++ b/spec/active_record_base_spec.rb
@@ -6,6 +6,69 @@ describe ActiveRecord::Base do
     EconomicSchool.delete_all
   end
 
+  # A secondary connection pool simulates a sharded connection — one that belongs
+  # to a different pool than ActiveRecord::Base. The old implementation used
+  # ActiveRecord::Base.uncached, which only disables the cache on ActiveRecord::Base's
+  # pool and has no effect on secondary pools.
+  describe "with a subclass using a secondary connection pool" do
+    let(:secondary_class) do
+      klass = Class.new(ActiveRecord::Base) { self.abstract_class = true }
+      stub_const("SecondaryTestConnection", klass)
+      klass.establish_connection(ActiveRecord::Base.connection_db_config)
+      klass
+    end
+    after(:each) { secondary_class.remove_connection if secondary_class.connected? }
+
+    it 'pluck_from_sql bypasses the cache on a subclass using a different pool than ActiveRecord::Base' do
+      sql = "SELECT random()"
+      value_1 = value_2 = nil
+
+      secondary_class.cache do
+        value_1 = secondary_class.pluck_from_sql(sql)
+        value_2 = secondary_class.pluck_from_sql(sql)
+      end
+
+      expect(value_1).not_to eq(value_2)
+    end
+
+    it 'value_from_sql bypasses the cache on a subclass using a different pool than ActiveRecord::Base' do
+      sql = "SELECT random()"
+      value_1 = value_2 = nil
+
+      secondary_class.cache do
+        value_1 = secondary_class.value_from_sql(sql)
+        value_2 = secondary_class.value_from_sql(sql)
+      end
+
+      expect(value_1).not_to eq(value_2)
+    end
+
+    it 'tuple_from_sql bypasses the cache on a subclass using a different pool than ActiveRecord::Base' do
+      sql = "SELECT random()"
+      value_1 = value_2 = nil
+
+      secondary_class.cache do
+        value_1 = secondary_class.tuple_from_sql(sql)
+        value_2 = secondary_class.tuple_from_sql(sql)
+      end
+
+      expect(value_1).not_to eq(value_2)
+    end
+
+    it 'structs_from_sql bypasses the cache on a subclass using a different pool than ActiveRecord::Base' do
+      test_struct = Struct.new(:r)
+      sql = "SELECT random() AS r"
+      value_1 = value_2 = nil
+
+      secondary_class.cache do
+        value_1 = secondary_class.structs_from_sql(test_struct, sql)
+        value_2 = secondary_class.structs_from_sql(test_struct, sql)
+      end
+
+      expect(value_1).not_to eq(value_2)
+    end
+  end
+
   describe "#pluck_from_sql" do
     it 'allows plucking with SQL directly' do
       sql = "SELECT 1 * 23"

--- a/spec/active_record_connection_adapter_spec.rb
+++ b/spec/active_record_connection_adapter_spec.rb
@@ -8,6 +8,70 @@ describe ActiveRecord::ConnectionAdapters::AbstractAdapter do
 
   let(:connection) { ActiveRecord::Base.connection }
 
+  # A secondary connection pool simulates a sharded connection — one that belongs
+  # to a different pool than ActiveRecord::Base. The old implementation used
+  # ActiveRecord::Base.uncached, which only disables the cache on ActiveRecord::Base's
+  # pool and has no effect on secondary pools.
+  context "with a secondary connection pool" do
+    let(:secondary_class) do
+      klass = Class.new(ActiveRecord::Base) { self.abstract_class = true }
+      stub_const("SecondaryTestConnection", klass)
+      klass.establish_connection(ActiveRecord::Base.connection_db_config)
+      klass
+    end
+    let(:secondary_connection) { secondary_class.connection }
+    after(:each) { secondary_class.remove_connection if secondary_class.connected? }
+
+    it 'pluck_from_sql bypasses the cache on a connection belonging to a different pool than ActiveRecord::Base' do
+      sql = "SELECT random()"
+      value_1 = value_2 = nil
+
+      secondary_class.cache do
+        value_1 = secondary_connection.pluck_from_sql(sql)
+        value_2 = secondary_connection.pluck_from_sql(sql)
+      end
+
+      expect(value_1).not_to eq(value_2)
+    end
+
+    it 'value_from_sql bypasses the cache on a connection belonging to a different pool than ActiveRecord::Base' do
+      sql = "SELECT random()"
+      value_1 = value_2 = nil
+
+      secondary_class.cache do
+        value_1 = secondary_connection.value_from_sql(sql)
+        value_2 = secondary_connection.value_from_sql(sql)
+      end
+
+      expect(value_1).not_to eq(value_2)
+    end
+
+    it 'tuple_from_sql bypasses the cache on a connection belonging to a different pool than ActiveRecord::Base' do
+      sql = "SELECT random()"
+      value_1 = value_2 = nil
+
+      secondary_class.cache do
+        value_1 = secondary_connection.tuple_from_sql(sql)
+        value_2 = secondary_connection.tuple_from_sql(sql)
+      end
+
+      expect(value_1).not_to eq(value_2)
+    end
+
+    it 'structs_from_sql bypasses the cache on a connection belonging to a different pool than ActiveRecord::Base' do
+      test_struct = Struct.new(:r)
+      sql = "SELECT random() AS r"
+      value_1 = value_2 = nil
+
+      secondary_class.cache do
+        value_1 = secondary_connection.structs_from_sql(test_struct, sql)
+        value_2 = secondary_connection.structs_from_sql(test_struct, sql)
+      end
+
+      expect(value_1).not_to eq(value_2)
+    end
+  end
+
   describe "#pluck_from_sql" do
     it 'allows plucking with SQL directly' do
       sql = "SELECT 1 * 23"

--- a/spec/active_record_connection_adapter_spec.rb
+++ b/spec/active_record_connection_adapter_spec.rb
@@ -12,7 +12,7 @@ describe ActiveRecord::ConnectionAdapters::AbstractAdapter do
   # to a different pool than ActiveRecord::Base. The old implementation used
   # ActiveRecord::Base.uncached, which only disables the cache on ActiveRecord::Base's
   # pool and has no effect on secondary pools.
-  context "with a secondary connection pool" do
+  describe "with a secondary connection pool" do
     let(:secondary_class) do
       klass = Class.new(ActiveRecord::Base) { self.abstract_class = true }
       stub_const("SecondaryTestConnection", klass)


### PR DESCRIPTION
## Summary
- ActiveRecord::Base.uncached only disables the query cache on ActiveRecord::Base's connection pool. When called on a connection belonging to a different pool (e.g. a sharded connection), the cache was not bypassed. Switching to uncached without the ActiveRecord::Base receiver fixes this, since AbstractAdapter#uncached delegates to the connection's own pool.
- Bump sqlite3 development dependency to >= 2.1 to align with Rails 8 requirements.
- Bump version

## Test plan

- Added a `context "with a secondary connection pool"` block that creates a separate connection pool and verifies each method bypasses the cache on that pool — the scenario that was broken before this fix.
